### PR TITLE
Fix StatefulSet manifest

### DIFF
--- a/thanos-store-statefulSet.yaml.tf
+++ b/thanos-store-statefulSet.yaml.tf
@@ -127,14 +127,12 @@ resource "kubernetes_manifest" "statefulset_thanos_store" {
               "volumeMounts" = [
                 {
                   "mountPath" = "/var/thanos/store"
-                  "name" = "data"
-                  "readOnly" = false
+                  "name"      = "data"
                 },
               ]
             },
           ]
           "terminationGracePeriodSeconds" = 120
-          "volumes" = []
         }
       }
       "volumeClaimTemplates" = [


### PR DESCRIPTION
This should fix the StatefulSet manifest:

* `readOnly" = false` is not needed. It's the default value and the API somehow swallows it and doesn't return it on apply response, confusing `terraform` when it saves the state.
* `"volumes" = []` is meaningless and has no effect. It confuses `terraform` when saving the state.